### PR TITLE
implement K8S_TEST_NAMESPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,10 +590,17 @@ kubeconfig(
 
 An executable that performs Kubernetes test setup:
 
-- creates temporary namespace
+- creates temporary namespace.
 - creates kubectl configuration with the default context set to the created namespace
 - deploys all dependent ***objects***
 - forwards service ports
+
+There are two ways to override the name of the namespace created by the `k8s_test_setup` rule:
+
+- specify a `K8S_TEST_NAMESPACE` environment variable. The value of the environment variable will be used as the namespace name.
+- specify a `K8S_MYNAMESPACE` environment variable. The presence of the variable would trigger the `k8s_test_setup` rule to use a namespace with the `whoami` name, typically reusing the `mynamespace` environment.
+
+In both cases, the namespace will not be deleted after the test is finished. This is useful for debugging purposes.
 
 | Parameter                  | Default        | Description
 | -------------------------- | -------------- | -----------

--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -46,7 +46,13 @@ echo "Cluster: ${CLUSTER}" >&2
 echo "User: ${USER}" >&2
 
 set +e
-if [ -n "${K8S_MYNAMESPACE:-}" ]
+if [ -n "${K8S_TEST_NAMESPACE:-}" ]
+then
+    # use provided namespace
+    NAMESPACE=${K8S_TEST_NAMESPACE}
+    # do not delete namespace after the test is complete
+    DELETE_NAMESPACE_FLAG=""
+elif [ -n "${K8S_MYNAMESPACE:-}" ]
 then
     # do not create random namesspace
     NAMESPACE=`whoami`

--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -55,7 +55,7 @@ then
 elif [ -n "${K8S_MYNAMESPACE:-}" ]
 then
     # do not create random namesspace
-    NAMESPACE=`whoami`
+    NAMESPACE=$(whoami)
     # do not delete namespace after the test is complete
     DELETE_NAMESPACE_FLAG=""
 else


### PR DESCRIPTION
implement K8S_TEST_NAMESPACE to allow to run integration test in specified namespace.
This is a backwards-compatible reimplementation of https://github.com/adobe/rules_gitops/commit/3159eb68572ed9cdbc8e0a537644c53464de5a58