### PR TITLE
more conditions to terminate integration test earlier

### DIFF
--- a/testing/it_sidecar/it_sidecar.go
+++ b/testing/it_sidecar/it_sidecar.go
@@ -371,7 +371,13 @@ func main() {
 	clientset = kubernetes.NewForConfigOrDie(config)
 	defer cleanup(clientset)
 
-	go stern.Run(ctx, *namespace, clientset, allowErrors)
+	go func() {
+		err := stern.Run(ctx, *namespace, clientset, allowErrors)
+		if err != nil {
+			log.Print(err)
+		}
+		cancel()
+	}()
 
 	listenForEvents(ctx, clientset, func(event *v1.Event) {
 		if !allowErrors {

--- a/testing/it_sidecar/it_sidecar.go
+++ b/testing/it_sidecar/it_sidecar.go
@@ -91,6 +91,7 @@ func contains(v []string, item string) bool {
 	}
 	return false
 }
+
 // listReadyApps converts a list returned from podsInformer.GetStore().List() to a map containing apps with ready status
 // app is determined by app label
 func listReadyApps(list []interface{}) (readypods, notReady []string) {
@@ -138,7 +139,7 @@ func listenForEvents(ctx context.Context, clientset *kubernetes.Clientset, onFai
 			return
 		}
 		log.Printf("EVENT %s %s %s %s\n", event.Namespace, event.InvolvedObject.Name, event.Reason, event.Message)
-		if event.Reason == "Failed" {
+		if event.Reason == "Failed" || event.Reason == "BackOff" {
 			onFailure(event)
 		}
 	}

--- a/testing/it_sidecar/it_sidecar.go
+++ b/testing/it_sidecar/it_sidecar.go
@@ -371,7 +371,7 @@ func main() {
 	clientset = kubernetes.NewForConfigOrDie(config)
 	defer cleanup(clientset)
 
-	go stern.Run(ctx, *namespace, clientset)
+	go stern.Run(ctx, *namespace, clientset, allowErrors)
 
 	listenForEvents(ctx, clientset, func(event *v1.Event) {
 		if !allowErrors {

--- a/testing/it_sidecar/stern/main.go
+++ b/testing/it_sidecar/stern/main.go
@@ -23,11 +23,11 @@ import (
 )
 
 // Run starts the main run loop
-func Run(ctx context.Context, namespace string, clientset *kubernetes.Clientset) error {
+func Run(ctx context.Context, namespace string, clientset *kubernetes.Clientset, allowErrors bool) error {
 
 	tails := make(map[string]*Tail)
 
-	err := Watch(ctx, clientset.CoreV1().Pods(namespace), RUNNING, labels.Everything(), func(p *Target) {
+	err := Watch(ctx, clientset.CoreV1().Pods(namespace), RUNNING, labels.Everything(), allowErrors, func(p *Target) {
 		id := p.GetID()
 		if tails[id] != nil {
 			return
@@ -45,7 +45,7 @@ func Run(ctx context.Context, namespace string, clientset *kubernetes.Clientset)
 		delete(tails, id)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to set up watch: %v", err)
+		return fmt.Errorf("watch error: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
integration test should also be terminated early
- if any container state in the namespace is BackOff
- if any container exited with nonzero error code and Reason: Error