### PR TITLE
reimplement image aliases

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.50.0",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.4.1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_oci", version = "1.7.2")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1337,7 +1337,7 @@
   "moduleExtensions": {
     "//gitops:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5Wg3kxup7pYafCf0D82azWWCB3UgJlGHWwJmdsdcV8w=",
+        "bzlTransitiveDigest": "w0udGZ06pjvfPfwBEH3vYbxVT3GDtEeATpwctPJcC9o=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1337,7 +1337,7 @@
   "moduleExtensions": {
     "//gitops:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "w0udGZ06pjvfPfwBEH3vYbxVT3GDtEeATpwctPJcC9o=",
+        "bzlTransitiveDigest": "s29xWb2UpPurky6o814An1h9fK171yCKFOhVlz299LA=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/gitops/deps.bzl
+++ b/gitops/deps.bzl
@@ -47,9 +47,9 @@ def rules_gitops_dependencies():
     maybe(
         http_archive,
         name = "aspect_bazel_lib",
-        sha256 = "979667bb7276ee8fcf2c114c9be9932b9a3052a64a647e0dcaacfb9c0016f0a3",
-        strip_prefix = "bazel-lib-2.4.1",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.4.1/bazel-lib-v2.4.1.tar.gz",
+        sha256 = "b554eb7942a5ab44c90077df6a0c76fc67c5874c9446a007e9ba68be82bd4796",
+        strip_prefix = "bazel-lib-2.7.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.4.1/bazel-lib-v2.7.1.tar.gz",
     )
 
     maybe(

--- a/gitops/provider.bzl
+++ b/gitops/provider.bzl
@@ -18,3 +18,10 @@ GitopsArtifactsInfo = provider(
         "deployment_branch": "Branch to merge manifests into and create a PR from.",
     },
 )
+
+AliasInfo = provider(
+    "Alias for an image to be used in a manifest",
+    fields = {
+        "alias": "Alias for a target",
+    },
+)

--- a/gitops/testing/BUILD
+++ b/gitops/testing/BUILD
@@ -19,9 +19,9 @@ k8s_deploy(
     cluster = "testcluster",
     deployment_branch = "test1",
     gitops = 1,
-    images = [
-        "//skylib/kustomize/tests:image",
-    ],
+    images = {
+        "testimage": "//skylib/kustomize/tests:image",
+    },
     manifests = [
         ":deployment_legacy.yaml",
     ],
@@ -98,9 +98,9 @@ k8s_deploy(
     cluster = "testcluster",
     deployment_branch = "test1",
     gitops = 1,
-    images = [
-        ":pushed_image",
-    ],
+    images = {
+        "testimage": ":pushed_image",
+    },
     manifests = [
         ":deployment_legacy.yaml",
     ],

--- a/gitops/testing/legacy_alias_expected.yaml
+++ b/gitops/testing/legacy_alias_expected.yaml
@@ -13,5 +13,5 @@ spec:
         app: myapp
     spec:
       containers:
-      - image: docker.io/skylib/kustomize/tests/image@sha256:1fa852d8eaf0f0a491713fb8c62c13ab8d25e2d6b32f024e49513f12a2e57b7a
+      - image: docker.io/skylib/kustomize/tests/image@sha256:1abae145a9069d0f4fdf9a0527ff5aec503ec02c3df783e25172895745dd2172
         name: myapp

--- a/gitops/testing/legacy_label_expected.yaml
+++ b/gitops/testing/legacy_label_expected.yaml
@@ -13,5 +13,5 @@ spec:
         app: myapp
     spec:
       containers:
-      - image: docker.io/skylib/kustomize/tests/image@sha256:1fa852d8eaf0f0a491713fb8c62c13ab8d25e2d6b32f024e49513f12a2e57b7a
+      - image: docker.io/skylib/kustomize/tests/image@sha256:1abae145a9069d0f4fdf9a0527ff5aec503ec02c3df783e25172895745dd2172
         name: myapp

--- a/gitops/testing/legacy_renamed_alias_expected.yaml
+++ b/gitops/testing/legacy_renamed_alias_expected.yaml
@@ -13,5 +13,5 @@ spec:
         app: myapp
     spec:
       containers:
-      - image: gcr.io/repo/imagethere@sha256:1fa852d8eaf0f0a491713fb8c62c13ab8d25e2d6b32f024e49513f12a2e57b7a
+      - image: gcr.io/repo/imagethere@sha256:1abae145a9069d0f4fdf9a0527ff5aec503ec02c3df783e25172895745dd2172
         name: myapp

--- a/push_oci/tests/BUILD.bazel
+++ b/push_oci/tests/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@rules_oci//oci:defs.bzl", "oci_image")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("//push_oci:push_oci.bzl", "push_oci")
 
-pkg_tar(
+tar(
     name = "image_tar",
     srcs = [":container_content.txt"],
 )

--- a/skylib/kustomize/tests/BUILD
+++ b/skylib/kustomize/tests/BUILD
@@ -10,10 +10,10 @@
 
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 load("@rules_oci//oci:defs.bzl", "oci_image")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//push_oci:push_oci.bzl", "push_oci_rule")
 load("//skylib/kustomize:kustomize.bzl", "gitops", "kubectl", "kustomize", "push_all")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 
 # to generate new test data if needed:
 # bazel run //skylib/kustomize:set_namespace newnamespace-1 <test.yaml >test_expected.yaml
@@ -73,7 +73,7 @@ kustomize(
     namespace = "",
 )
 
-pkg_tar(
+tar(
     name = "image_tar",
     srcs = [":container_content.txt"],
 )

--- a/skylib/kustomize/tests/BUILD
+++ b/skylib/kustomize/tests/BUILD
@@ -12,6 +12,7 @@ load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 load("@rules_oci//oci:defs.bzl", "oci_image")
 load("//push_oci:push_oci.bzl", "push_oci_rule")
 load("//skylib/kustomize:kustomize.bzl", "gitops", "kubectl", "kustomize", "push_all")
+load("//skylib:push_alias.bzl", "pushed_image_alias")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 
@@ -93,6 +94,12 @@ push_oci_rule(
     visibility = ["//visibility:public"],
 )
 
+pushed_image_alias(
+    name = "image_alias",
+    alias = "testimage",
+    pushed_image = ":image_push",
+)
+
 kustomize(
     name = "image_test",
     images = [
@@ -102,6 +109,17 @@ kustomize(
         "deployment.yaml",
         "service.yaml",
         "crb.yaml",
+    ],
+    namespace = "",
+)
+
+kustomize(
+    name = "alias_test",
+    images = [
+        ":image_alias",
+    ],
+    manifests = [
+        "deployment_with_alias.yaml",
     ],
     namespace = "",
 )
@@ -255,6 +273,7 @@ write_source_files(
         "expected_raw_test.yaml": ":raw_test",
         "expected_raw2_test.yaml": ":raw2_test",
         "expected_image_resolved_test.yaml": ":image_test",
+        "expected_alias_test.yaml": ":alias_test",
         "expected_configmap_test.yaml": ":configmap_test",
         "expected_secret_test.yaml": ":secret_test",
         "expected_patch_test.yaml": ":patch",

--- a/skylib/kustomize/tests/deployment_with_alias.yaml
+++ b/skylib/kustomize/tests/deployment_with_alias.yaml
@@ -13,5 +13,4 @@ spec:
     spec:
       containers:
       - name: myapp
-        image: testimage
-
+        image: //skylib/kustomize/tests:image

--- a/skylib/kustomize/tests/expected_alias_test.yaml
+++ b/skylib/kustomize/tests/expected_alias_test.yaml
@@ -12,6 +12,5 @@ spec:
         app: myapp
     spec:
       containers:
-      - name: myapp
-        image: testimage
-
+      - image: gcr.io/bs-dev/test_image@sha256:1abae145a9069d0f4fdf9a0527ff5aec503ec02c3df783e25172895745dd2172
+        name: myapp

--- a/skylib/kustomize/tests/expected_image_resolved_test.yaml
+++ b/skylib/kustomize/tests/expected_image_resolved_test.yaml
@@ -35,5 +35,5 @@ spec:
         app: myapp
     spec:
       containers:
-      - image: gcr.io/bs-dev/test_image@sha256:1fa852d8eaf0f0a491713fb8c62c13ab8d25e2d6b32f024e49513f12a2e57b7a
+      - image: gcr.io/bs-dev/test_image@sha256:1abae145a9069d0f4fdf9a0527ff5aec503ec02c3df783e25172895745dd2172
         name: myapp

--- a/skylib/kustomize/tests/expected_patch_test.yaml
+++ b/skylib/kustomize/tests/expected_patch_test.yaml
@@ -12,7 +12,7 @@ spec:
         app: myapp
     spec:
       containers:
-      - image: gcr.io/bs-dev/test_image@sha256:1fa852d8eaf0f0a491713fb8c62c13ab8d25e2d6b32f024e49513f12a2e57b7a
+      - image: gcr.io/bs-dev/test_image@sha256:1abae145a9069d0f4fdf9a0527ff5aec503ec02c3df783e25172895745dd2172
         name: myapp
         resources:
           limits:

--- a/skylib/push_alias.bzl
+++ b/skylib/push_alias.bzl
@@ -4,22 +4,42 @@ Provides a legacy interface for using short aliases for images instead of the fu
 Using aliases in new code is not recommended, as it creates a unnecessary level of indirection.
 """
 
-load("//gitops:provider.bzl", "GitopsPushInfo")
+load("//gitops:provider.bzl", "AliasInfo", "GitopsPushInfo")
 
 def _push_alias_impl(ctx):
-    #write digest to a file
+    default_info = ctx.attr.pushed_image[DefaultInfo]
+    files = default_info.files
+    new_executable = None
+    original_executable = default_info.files_to_run.executable
+    runfiles = default_info.default_runfiles
+
+    new_executable = ctx.outputs.executable
+
+    ctx.actions.symlink(
+        output = new_executable,
+        target_file = original_executable,
+        is_executable = True,
+    )
+    files = depset(direct = [new_executable], transitive = [files])
+    runfiles = runfiles.merge(ctx.runfiles([new_executable]))
+
     return [
-        ctx.attr.pushed_image[DefaultInfo],
+        DefaultInfo(
+            files = files,
+            runfiles = runfiles,
+            executable = new_executable,
+        ),
         ctx.attr.pushed_image[GitopsPushInfo],
         AliasInfo(
             alias = ctx.attr.alias,
         ),
     ]
 
-pushed_iamge_alias = rule(
+pushed_image_alias = rule(
     implementation = _push_alias_impl,
     attrs = {
         "pushed_image": attr.label(mandatory = True, providers = (GitopsPushInfo,), doc = "The pushed image like k8s_image_push"),
         "alias": attr.string(mandatory = True, doc = "The alias to be added to the pushed image"),
     },
+    executable = True,
 )

--- a/skylib/push_alias.bzl
+++ b/skylib/push_alias.bzl
@@ -1,0 +1,25 @@
+"""
+Implementation of the wrapper that would add an alias to a pushed image.
+Provides a legacy interface for using short aliases for images instead of the full bazel target path.
+Using aliases in new code is not recommended, as it creates a unnecessary level of indirection.
+"""
+
+load("//gitops:provider.bzl", "GitopsPushInfo")
+
+def _push_alias_impl(ctx):
+    #write digest to a file
+    return [
+        ctx.attr.pushed_image[DefaultInfo],
+        ctx.attr.pushed_image[GitopsPushInfo],
+        AliasInfo(
+            alias = ctx.attr.alias,
+        ),
+    ]
+
+pushed_iamge_alias = rule(
+    implementation = _push_alias_impl,
+    attrs = {
+        "pushed_image": attr.label(mandatory = True, providers = (GitopsPushInfo,), doc = "The pushed image like k8s_image_push"),
+        "alias": attr.string(mandatory = True, doc = "The alias to be added to the pushed image"),
+    },
+)


### PR DESCRIPTION
image alias is deprecated and it is not recommended for new code.
To make legacy code migration easier, it is reimplemented to support other types of pushed images (mirror, external image etc)