### PR TITLE
log context cancellation reasons

### DIFF
--- a/.fasterci/config.yaml
+++ b/.fasterci/config.yaml
@@ -12,6 +12,8 @@ workflows:
     steps:
       - name: Build & test
         bazel:
+          build_flags:
+            - --enable_bzlmod=false
           build_targets:
             - //...
           test_targets:
@@ -19,6 +21,8 @@ workflows:
       - name: Build & test e2e
         working-directory: e2e
         bazel:
+          build_flags:
+            - --enable_bzlmod=false
           build_targets:
             - //...
           test_targets:
@@ -31,11 +35,11 @@ workflows:
           build_targets:
             - //...
           build_flags:
-            - --config=bzlmod
+            - --enable_bzlmod
           test_targets:
             - //...
           test_flags:
-            - --config=bzlmod
+            - --enable_bzlmod
             - --test_size_filters=-large,-enormous
 
   - <<: *build_workflow

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,6 +21,12 @@ http_archive(
     ],
 )
 
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.21.6")
+
 http_archive(
     name = "buildifier_prebuilt",
     sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
@@ -41,12 +47,6 @@ bazel_skylib_workspace()
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.21.6")
 
 #
 # Self dependencies

--- a/e2e/WORKSPACE
+++ b/e2e/WORKSPACE
@@ -22,10 +22,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    sha256 = "6734a719993b1ba4ebe9806e853864395a8d3968ad27f9dd759c196b3eb3abe8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip",
     ],
 )
 
@@ -33,7 +33,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.20.6")
+go_register_toolchains(version = "1.21.6")
 
 load("@rules_gitops//gitops:deps.bzl", "rules_gitops_dependencies")
 

--- a/gitops/deps.bzl
+++ b/gitops/deps.bzl
@@ -49,7 +49,7 @@ def rules_gitops_dependencies():
         name = "aspect_bazel_lib",
         sha256 = "b554eb7942a5ab44c90077df6a0c76fc67c5874c9446a007e9ba68be82bd4796",
         strip_prefix = "bazel-lib-2.7.1",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.4.1/bazel-lib-v2.7.1.tar.gz",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.1/bazel-lib-v2.7.1.tar.gz",
     )
 
     maybe(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fasterci/rules_gitops
 
-go 1.19
+go 1.21
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/testing/it_sidecar/it_sidecar.go
+++ b/testing/it_sidecar/it_sidecar.go
@@ -340,11 +340,15 @@ func cleanup(clientset *kubernetes.Clientset) {
 	}
 }
 
+var ErrTimedOut = errors.New("timed out")
+var ErrStdinClosed = errors.New("stdin closed")
+
 func main() {
 	flag.Parse()
 	log.SetOutput(os.Stdout)
-	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
-	defer cancel()
+	ctx, timeoutCancel := context.WithTimeoutCause(context.Background(), *timeout, ErrTimedOut)
+	defer timeoutCancel()
+	ctx, cancel := context.WithCancelCause(ctx)
 	ctx, stopSignal := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stopSignal()
 	// cancel context if stdin is closed
@@ -353,7 +357,7 @@ func main() {
 		for {
 			_, _, err := reader.ReadRune()
 			if err != nil && err == io.EOF {
-				cancel()
+				cancel(ErrStdinClosed)
 				break
 			}
 		}
@@ -378,13 +382,13 @@ func main() {
 		if err != nil {
 			log.Print(err)
 		}
-		cancel()
+		cancel(fmt.Errorf("terminate due to kubernetes listening failure: %w", err))
 	}()
 
 	listenForEvents(ctx, clientset, func(event *v1.Event) {
 		if !allowErrors {
 			log.Println("Terminate due to failure")
-			cancel()
+			cancel(fmt.Errorf("terminate due to event %s/%s %s %s", event.Namespace, event.InvolvedObject.Name, event.Reason, event.Message))
 		}
 	})
 
@@ -405,4 +409,13 @@ func main() {
 
 	fmt.Println("READY")
 	<-ctx.Done()
+	switch ctx.Err() {
+	case context.DeadlineExceeded:
+		log.Print("Deadline exceeded")
+	case context.Canceled:
+		log.Print("Context Canceled")
+	default:
+		log.Print(ctx.Err())
+	}
+
 }


### PR DESCRIPTION
It is hard to debug a test failure caused by finished context. Possible reasons are:
- timeout
- signal
- stdin closed
- error watching k8s events
Better logging of the reason for context cancellation should help in this case.
