### PR TITLE
create a github.com/fasterci/rules_gitops/testing/it_sidecar/client go module

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -2,4 +2,6 @@ module github.com/fasterci/rules_gitops/e2e
 
 go 1.20
 
-require github.com/fasterci/rules_gitops v0.18.0
+require github.com/fasterci/rules_gitops/testing/it_sidecar/client v0.31.8
+
+replace github.com/fasterci/rules_gitops/testing/it_sidecar/client => ../testing/it_sidecar/client

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1,2 +1,0 @@
-github.com/fasterci/rules_gitops v0.18.0 h1:VXG5WNHCA26pA72aqcyeUjXYkBXDyAQxS33QFs4czHw=
-github.com/fasterci/rules_gitops v0.18.0/go.mod h1:vdARypk35U3M/1EAmFRptiSbzXg9FMQPe8D33Am7rHY=

--- a/testing/it_sidecar/client/go.mod
+++ b/testing/it_sidecar/client/go.mod
@@ -1,0 +1,3 @@
+module github.com/fasterci/rules_gitops/testing/it_sidecar/client
+
+go 1.20


### PR DESCRIPTION
adding a dependency to `github.com/fasterci/rules_gitops/testing/it_sidecar/client` in go test is required to interact with it sidecar.
Adding `github.com/fasterci/rules_gitops` module brings a lot of unnecessary dependencies while the sidecar client only requires a standard library.
Adding a module would fix that.
