### PR TITLE
Support for rules_oci 2.x (using bzlmod)

### DIFF
--- a/gitops/extensions.bzl
+++ b/gitops/extensions.bzl
@@ -6,7 +6,7 @@ TODO: implement a proper toolchain resolution mechanism in bzlmod
 load("//gitops/private:extension_utils.bzl", "extension_utils")
 load("//gitops/private:host_repo.bzl", "host_repo")
 load(
-    ":repositories.bzl",
+    ":toolchains.bzl",
     "DEFAULT_KUSTOMIZE_REPOSITORY",
     "DEFAULT_KUSTOMIZE_VERSION",
     "register_kustomize_toolchains",

--- a/gitops/repositories.bzl
+++ b/gitops/repositories.bzl
@@ -15,13 +15,16 @@ GtiOps rules repositories initialization
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-load("@rules_gitops//skylib/kustomize:kustomize.bzl", "download_kustomize", "kustomize_setup")
+load("@rules_gitops//skylib/kustomize:kustomize.bzl", "kustomize_setup")
 load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-load("//gitops/private:kustomize_toolchain.bzl", "KUSTOMIZE_PLATFORMS", "kustomize_host_alias_repo", "kustomize_platform_repo", "kustomize_toolchains_repo", _DEFAULT_KUSTOMIZE_VERSION = "DEFAULT_KUSTOMIZE_VERSION")
-
-DEFAULT_KUSTOMIZE_VERSION = _DEFAULT_KUSTOMIZE_VERSION
+load(
+    ":toolchains.bzl",
+    _register_kustomize_toolchains = "register_kustomize_toolchains",
+    _DEFAULT_KUSTOMIZE_REPOSITORY = "DEFAULT_KUSTOMIZE_REPOSITORY",
+    _DEFAULT_KUSTOMIZE_VERSION = "DEFAULT_KUSTOMIZE_VERSION",
+)
 
 def rules_gitops_repositories():
     """Initializes Declares workspaces the GitOps rules depend on.
@@ -43,31 +46,7 @@ def rules_gitops_repositories():
         crane_version = LATEST_CRANE_VERSION,
     )
 
-DEFAULT_KUSTOMIZE_REPOSITORY = "kustomize"
-
-def register_kustomize_toolchains(name = DEFAULT_KUSTOMIZE_REPOSITORY, version = DEFAULT_KUSTOMIZE_VERSION, register = True):
-    """Registers kustomize toolchain and repositories
-
-    Args:
-        name: override the prefix for the generated toolchain repositories
-        version: the version of kustomize to execute (see https://github.com/kubernetes-sigs/kustomize/releases)
-        register: whether to call through to native.register_toolchains.
-            Should be True for WORKSPACE users, but false when used under bzlmod extension
-    """
-
-    download_kustomize(name = "kustomize_bin")
-    for [platform, meta] in KUSTOMIZE_PLATFORMS.items():
-        kustomize_platform_repo(
-            name = "%s_%s" % (name, platform),
-            platform = platform,
-            version = version,
-        )
-        if register:
-            native.register_toolchains("@%s_toolchains//:%s_toolchain" % (name, platform))
-
-    kustomize_host_alias_repo(name = name)
-
-    kustomize_toolchains_repo(
-        name = "%s_toolchains" % name,
-        user_repository_name = name,
-    )
+# Re-host for backwards compatiblity
+register_kustomize_toolchains = _register_kustomize_toolchains
+DEFAULT_KUSTOMIZE_REPOSITORY = _DEFAULT_KUSTOMIZE_REPOSITORY
+DEFAULT_KUSTOMIZE_VERSION = _DEFAULT_KUSTOMIZE_VERSION

--- a/gitops/toolchains.bzl
+++ b/gitops/toolchains.bzl
@@ -1,0 +1,45 @@
+# Copyright 2020 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""
+Toolchain registration macros.
+"""
+load("//skylib/kustomize:kustomize.bzl", "download_kustomize")
+load("//gitops/private:kustomize_toolchain.bzl", "KUSTOMIZE_PLATFORMS", "kustomize_host_alias_repo", "kustomize_platform_repo", "kustomize_toolchains_repo", _DEFAULT_KUSTOMIZE_VERSION = "DEFAULT_KUSTOMIZE_VERSION")
+
+DEFAULT_KUSTOMIZE_VERSION = _DEFAULT_KUSTOMIZE_VERSION
+DEFAULT_KUSTOMIZE_REPOSITORY = "kustomize"
+
+def register_kustomize_toolchains(name = DEFAULT_KUSTOMIZE_REPOSITORY, version = DEFAULT_KUSTOMIZE_VERSION, register = True):
+    """Registers kustomize toolchain and repositories
+
+    Args:
+        name: override the prefix for the generated toolchain repositories
+        version: the version of kustomize to execute (see https://github.com/kubernetes-sigs/kustomize/releases)
+        register: whether to call through to native.register_toolchains.
+            Should be True for WORKSPACE users, but false when used under bzlmod extension
+    """
+
+    download_kustomize(name = "kustomize_bin")
+    for [platform, meta] in KUSTOMIZE_PLATFORMS.items():
+        kustomize_platform_repo(
+            name = "%s_%s" % (name, platform),
+            platform = platform,
+            version = version,
+        )
+        if register:
+            native.register_toolchains("@%s_toolchains//:%s_toolchain" % (name, platform))
+
+    kustomize_host_alias_repo(name = name)
+
+    kustomize_toolchains_repo(
+        name = "%s_toolchains" % name,
+        user_repository_name = name,
+    )

--- a/push_oci/push_oci.bzl
+++ b/push_oci/push_oci.bzl
@@ -95,7 +95,7 @@ push_oci_rule = rule(
                 default = Label("//push_oci:tag.sh.tpl"),
                 allow_single_file = True,
             )},
-    toolchains = oci_push_lib.toolchains,
+    toolchains = ["@aspect_bazel_lib//lib:yq_toolchain_type"] + oci_push_lib.toolchains,
     executable = True,
     # provides = [GitopsPushInfo, DefaultInfo],
 )


### PR DESCRIPTION
I encountered two issues when upgrading to `rules_oci` 2.x. The same issues were also raised on Bazel Slack [here](https://bazelbuild.slack.com/archives/CA3NW13MH/p1718040259784339?thread_ts=1717794020.040249&cid=CA3NW13MH).

1. `@rules_oci//oci:repositories.bzl` no longer exports a `LATEST_CRANE_VERSION` variable. I refactored `repositories.bzl` and extracted toolchain-related stuff used by the bzlmod extension to a new `toolchains.bzl`. `repositories.bzl` still requires `LATEST_CRANE_VERSION`, but it's no longer loaded by the bzlmod extension, so doesn't cause failures.
2. `oci_push` no longer depends on the `yq` toolchain. I've updated `push_oci_rule` to explicitly depend on the `yq` toolchain in addition to whatever else the underlying `oci_push` implementation depends on.