### PR TITLE
cleanup test namespace

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 common --enable_bzlmod
 build --nolegacy_external_runfiles
+build --remote_download_all
 build --verbose_failures
 build --@io_bazel_rules_go//go/config:pure
 test --test_output=errors

--- a/e2e/.bazelrc
+++ b/e2e/.bazelrc
@@ -1,4 +1,5 @@
 build --action_env HOME --test_env HOME
 common:bzlmod --enable_bzlmod
+build --remote_download_all
 build --nolegacy_external_runfiles
 build --@io_bazel_rules_go//go/config:pure

--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -49,7 +49,7 @@ set +e
 
 ns_cleanup() {
     echo "Performing namespace ${NAMESPACE} cleanup..."
-    ${KUBECTL} --kubeconfig=${KUBECONFIG} --cluster=${CLUSTER} --user=${USER} delete namespace ${NAMESPACE}
+    ${KUBECTL} --kubeconfig=${KUBECONFIG} --cluster=${CLUSTER} --user=${USER} delete namespace --wait=false ${NAMESPACE}
 }
 
 if [ -n "${K8S_TEST_NAMESPACE:-}" ]

--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -46,21 +46,22 @@ echo "Cluster: ${CLUSTER}" >&2
 echo "User: ${USER}" >&2
 
 set +e
+
+ns_cleanup() {
+    echo "Performing namespace ${NAMESPACE} cleanup..."
+    ${KUBECTL} --kubeconfig=${KUBECONFIG} --cluster=${CLUSTER} --user=${USER} delete namespace ${NAMESPACE}
+}
+
 if [ -n "${K8S_TEST_NAMESPACE:-}" ]
 then
     # use provided namespace
     NAMESPACE=${K8S_TEST_NAMESPACE}
-    # do not delete namespace after the test is complete
-    DELETE_NAMESPACE_FLAG=""
 elif [ -n "${K8S_MYNAMESPACE:-}" ]
 then
     # do not create random namesspace
     NAMESPACE=$(whoami)
-    # do not delete namespace after the test is complete
-    DELETE_NAMESPACE_FLAG=""
 else
     # create random namespace
-    DELETE_NAMESPACE_FLAG="-delete_namespace"
     COUNT="0"
     while true; do
         NAMESPACE=`whoami`-$(( (RANDOM) + 32767 ))
@@ -71,6 +72,8 @@ else
             exit 1
         fi
     done
+    # delete namespace after the test is complete or failed
+    trap ns_cleanup EXIT
 fi
 echo "Namespace: ${NAMESPACE}" >&2
 set -e
@@ -110,4 +113,4 @@ function waitpids() {
 # create k8s objects
 %{statements}
 
-%{it_sidecar} -namespace=${NAMESPACE} %{sidecar_args} ${DELETE_NAMESPACE_FLAG} "$@"
+%{it_sidecar} -namespace=${NAMESPACE} %{sidecar_args} "$@"


### PR DESCRIPTION
kubectl failure in integration test setup script causes the script to exit prematurely so it_sidecar does not have a chance to perform the cleanup.
This PR adds a trap that would be executed on exit of the script whether it normal exit or by error. This also make the cleanup part of the it_sidecar obsolete.