### PR TITLE
mirror validation should pass with local image only; more testing for mirroring

### DIFF
--- a/mirror/mirror_image.sh
+++ b/mirror/mirror_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 set -eu
 
 function guess_runfiles() {

--- a/mirror/tests/BUILD.bazel
+++ b/mirror/tests/BUILD.bazel
@@ -202,3 +202,25 @@ sh_test(
     },
     tags = ["exclusive"],  # this test starts a registry on fixed port 1338
 )
+
+sh_test(
+    name = "image_mirror_verify_test",
+    srcs = ["image_mirror_test.sh"],
+    data = [
+        ":image_mirror",
+        ":image_mirror_validate_src",
+        ":push_image",
+        "//vendor/github.com/google/go-containerregistry/cmd/crane",
+        "//vendor/github.com/google/go-containerregistry/cmd/registry",
+    ],
+    env = {
+        "LOCAL": "localhost:1338/mirror/localhost1338/image@sha256:b812c0570a7c369b2863c64e22760dc1b1dbc025a739f02db376bac62862f4cc",
+        "REMOTE": "localhost:1338/image@sha256:b812c0570a7c369b2863c64e22760dc1b1dbc025a739f02db376bac62862f4cc",
+        "PUSH_IMAGE": "$(location :push_image)",
+        "IMAGE_MIRROR": "$(location :image_mirror)",
+        "IMAGE_MIRROR_VALIDATE_SRC": "$(location :image_mirror_validate_src)",
+        "CRANE_BIN": "$(location //vendor/github.com/google/go-containerregistry/cmd/crane)",
+        "REGISTRY_BIN": "$(location //vendor/github.com/google/go-containerregistry/cmd/registry)",
+    },
+    tags = ["exclusive"],  # this test starts a registry on fixed port 1338
+)

--- a/mirror/tests/image_mirror_test.sh
+++ b/mirror/tests/image_mirror_test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash -x
+#
+# This test runs the script passed as the first argument and verifies the image is pushed to the registry
+#
+${REGISTRY_BIN}&
+registry_pid=$!
+trap "kill -9 $registry_pid" EXIT
+
+echo verifying image $REMOTE does not exist
+${CRANE_BIN} validate -v --fast --remote $REMOTE
+if [ $? -eq 0 ]; then
+  echo "Image $REMOTE should not exist"
+  exit 1
+fi
+
+echo verifying image $LOCAL does not exist
+${CRANE_BIN} validate -v --fast --remote $LOCAL
+if [ $? -eq 0 ]; then
+  echo "Image $LOCAL should not exist"
+  exit 1
+fi
+
+#test should fail before pushing the image (no src, no dst)
+echo verifying mirror image validation fails
+${IMAGE_MIRROR_VALIDATE_SRC}
+if [ $? -eq 0 ]; then
+  echo "Image verification should fail"
+  exit 1
+fi
+
+echo pushing image $SRC_IMAGE
+${PUSH_IMAGE}
+
+echo verifying image $REMOTE exists
+${CRANE_BIN} validate -v --fast --remote $REMOTE
+if [ $? -ne 0 ]; then
+  echo "Image $REMOTE should exist"
+  exit 1
+fi
+
+echo verifying image $LOCAL does not exist
+${CRANE_BIN} validate -v --fast --remote $LOCAL
+if [ $? -eq 0 ]; then
+  echo "Image $LOCAL should not exist"
+  exit 1
+fi
+
+#test should succeed with src image only
+echo verifying mirror image validation fails
+${IMAGE_MIRROR_VALIDATE_SRC}
+if [ $? -ne 0 ]; then
+  echo "Image verification should succeed"
+  exit 1
+fi
+
+echo running image mirror
+${IMAGE_MIRROR}
+if [ $? -ne 0 ]; then
+  echo "Image mirroring should succeed"
+  exit 1
+fi
+
+echo verifying image $LOCAL exists
+${CRANE_BIN} validate -v --fast --remote $LOCAL
+if [ $? -ne 0 ]; then
+  echo "Image $LOCAL should exist"
+  exit 1
+fi
+
+echo verifying image $REMOTE exists
+${CRANE_BIN} validate -v --fast --remote $REMOTE
+if [ $? -ne 0 ]; then
+  echo "Image $REMOTE should exist"
+  exit 1
+fi
+
+#test should succeed with src and dst images
+echo verifying mirror image validation succeeds
+${IMAGE_MIRROR_VALIDATE_SRC}
+if [ $? -ne 0 ]; then
+  echo "Image verification should succeed"
+  exit 1
+fi
+
+echo removing image $REMOTE
+${CRANE_BIN} delete $REMOTE || exit 1
+
+echo verifying image $REMOTE does not exist
+${CRANE_BIN} validate -v --fast --remote $REMOTE
+if [ $? -eq 0 ]; then
+  echo "Image $REMOTE should not exist"
+  exit 1
+fi
+
+echo verifying image $LOCAL exists
+${CRANE_BIN} validate -v --fast --remote $LOCAL
+if [ $? -ne 0 ]; then
+  echo "Image $LOCAL should exist"
+  exit 1
+fi
+
+#test should succeed with dst image only
+echo verifying mirror image validation succeeds
+${IMAGE_MIRROR_VALIDATE_SRC}
+if [ $? -ne 0 ]; then
+  echo "Image verification should succeed"
+  exit 1
+fi
+
+
+# exit 1

--- a/mirror/validate_image.sh
+++ b/mirror/validate_image.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 REMOTE="{src_image}"
 LOCAL="{dst_image}@{digest}"
-echo "Validating images $REMOTE and $LOCAL"
-{crane_tool} validate -v --fast --remote $REMOTE || {crane_tool} validate -v --fast --remote $LOCAL || exit 1
+echo "Validating images ${REMOTE} and ${LOCAL}"
+{crane_tool} validate -v --fast --remote ${REMOTE}
+if [ $? -eq 0 ]; then
+  echo "Image ${REMOTE} exist"
+  exit 0
+fi
+
+echo "Image ${REMOTE} does not exist, checking ${LOCAL}"
+
+{crane_tool} validate -v --fast --remote ${LOCAL}
+if [ $? -eq 0 ]; then
+  echo "Image ${LOCAL} exist"
+  exit 0
+fi
+
+echo "Image ${LOCAL} does not exist"
+exit 1

--- a/mirror/validate_image.sh
+++ b/mirror/validate_image.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-echo "Validating image $1"
-$CRANE_BIN validate -v --fast --remote $1
+REMOTE="{src_image}"
+LOCAL="{dst_image}@{digest}"
+echo "Validating images $REMOTE and $LOCAL"
+{crane_tool} validate -v --fast --remote $REMOTE || {crane_tool} validate -v --fast --remote $LOCAL || exit 1


### PR DESCRIPTION
Mirror always verify for remote image availability in a generated test to make sure we catch errors in image location or digest earlier.
However, the goal of the mirror was to increase external images availability if they suddenly disappear. The test should not fail in this case.
This PR modifies test to check local image if remote does not exist.
Also, it add more integration testing for mirroring