### PR TITLE
adds option to overide CLUSTER argument in k8s_test_setup

### DIFF
--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -39,7 +39,13 @@ NAMESPACE_NAME_FILE=${TEST_UNDECLARED_OUTPUTS_DIR}/namespace
 KUBECONFIG_FILE=${TEST_UNDECLARED_OUTPUTS_DIR}/kubeconfig
 
 # get cluster and username from provided configuration
-CLUSTER=$(cat ${CLUSTER_FILE})
+if [ -n "${K8S_TEST_CLUSTER:-}" ]
+then
+    CLUSTER=${K8S_TEST_CLUSTER}
+else
+    CLUSTER=$(cat ${CLUSTER_FILE})
+fi
+
 USER=$(${KUBECTL} --kubeconfig=${KUBECONFIG} config view -o jsonpath='{.users[?(@.name == '"\"${CLUSTER}\")].name}")
 
 echo "Cluster: ${CLUSTER}" >&2


### PR DESCRIPTION
K8S_TEST_CLUSTER test_env variable allows users to specify the cluster to use at the time of test execution (akin to the way we allow override of the namespace)