### PR TITLE
Add a .diff target for k8s_deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ For example, let's look at the [example's k8s_deploy](./e2e/helloworld/BUILD). W
 cd e2e
 bazel run //helloworld:mynamespace.show
 ```
+We can run `bazel run ///helloworld:mynamespace.diff` to see a difference from source to what is stored in kubernetes.
+
 When you run `bazel run ///helloworld:mynamespace.apply`, it applies this file into your personal (`{BUILD_USER}`) namespace. Viewing the rendered files with `.show` can be useful for debugging issues with invalid or misconfigured manifests.
 
 | Parameter                 | Default        | Description

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -223,6 +223,17 @@ def k8s_deploy(
             tags = tags,
             visibility = visibility,
         )
+        kubectl(
+            name = name + ".diff",
+            srcs = [name],
+            command = "diff",
+            cluster = cluster,
+            push = False,
+            user = user,
+            namespace = namespace,
+            tags = tags,
+            visibility = visibility,
+        )
         show(
             name = name + ".show",
             namespace = namespace,


### PR DESCRIPTION
Add a .diff target for k8s_deploy

## Description

Add to the list of generated targets for k8s_deploy so, in addition to .show and .delete, it also has .diff

## Related Issue

## Motivation and Context

As part of a CICD pipeline,  or testing, I'd like to see and record what the diff is between source and what kubernetes is actually running.

## How Has This Been Tested?

No. Can you point me to how to test this?

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
  - I don't find this file in this location: https://github.com/fasterci/rules_gitops/community  What do you want me to read?
- [ ] I have added tests to cover my changes.
