### PR TITLE
bazel 8 — use starlark `sh_binary` rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_oci", version = "1.7.2")
 bazel_dep(name = "rules_pkg", version = "0.9.1")
 bazel_dep(name = "rules_go", version = "0.44.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_shell", version = "0.4.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.21.5")

--- a/skylib/kustomize/BUILD
+++ b/skylib/kustomize/BUILD
@@ -8,6 +8,8 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 exports_files([
     "run-all.sh.tpl",
     "kubectl.sh.tpl",

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -26,6 +26,8 @@ def _download_kustomize_impl(ctx):
         fail("Platform " + ctx.os.name + " is not supported")
 
     ctx.file("BUILD", """
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 sh_binary(
     name = "kustomize",
     srcs = ["bin/kustomize"],


### PR DESCRIPTION
Updates BUILD files to use Starlark based `sh_*` rules

## Description

Bazel 8.0 moved all `sh_*` rules to `rules_shell` (https://blog.bazel.build/2024/12/09/bazel-8-release.html)

## How Has This Been Tested?

Used as a dependency within a project using Bazel 8.1.1

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
