### PR TITLE
RUNFILES_DIR env var undefined for `.push` run during a `.apply`

### DIFF
--- a/skylib/k8s_gitops.sh.tpl
+++ b/skylib/k8s_gitops.sh.tpl
@@ -51,7 +51,7 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 PIDS=()
 function async() {
     # Launch the command asynchronously and track its process id.
-    PYTHON_RUNFILES=${RUNFILES} "$@" &
+    PYTHON_RUNFILES=${RUNFILES} RUNFILES_DIR=${RUNFILES} "$@" &
     PIDS+=($!)
 }
 

--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -102,7 +102,7 @@ export PYTHON_RUNFILES=${RUNFILES}
 PIDS=()
 function async() {
     # Launch the command asynchronously and track its process id.
-    PYTHON_RUNFILES=${RUNFILES} "$@" &
+    PYTHON_RUNFILES=${RUNFILES} RUNFILES_DIR=${RUNFILES} "$@" &
     PIDS+=($!)
 }
 

--- a/skylib/kustomize/kubectl.sh.tpl
+++ b/skylib/kustomize/kubectl.sh.tpl
@@ -30,7 +30,7 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 PIDS=()
 function async() {
     # Launch the command asynchronously and track its process id.
-    PYTHON_RUNFILES=${RUNFILES} "$@" &
+    PYTHON_RUNFILES=${RUNFILES} RUNFILES_DIR=${RUNFILES} "$@" &
     PIDS+=($!)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I believe this is a bug — however I could be wrong.

Ran into issues with the RUNFILES_DIR var undefined while `.apply` from a github action runner environment. This PR fixed the issue for me. Opening this PR for a discussion or for this fix to be validated and merged.

## How Has This Been Tested?

Via internal GH actions

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
