### PR TITLE
Remove incompatible_use_toolchain_transition

### DIFF
--- a/gitops/private/kustomize_toolchain.bzl
+++ b/gitops/private/kustomize_toolchain.bzl
@@ -128,7 +128,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@rules_gitops//gitops:kustomize_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)


### PR DESCRIPTION
## Description

Remove `incompatible_use_toolchain_transition` from `gitops/private/kustomize_toolchain.bzl` as this kwarg has been removed in Bazel 9.
